### PR TITLE
feat: add custom fix functionality for AsciiDocDITA issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vale-online-app",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Run vale lint online based on https://github.com/redhat-documentation/vale-at-red-hat rules. Convert AsciiDoc to a DITA 1.3 topic.",
   "main": "server.js",
   "scripts": {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -94,6 +94,51 @@ body {
   background-color: #3f51b5;
 }
 
+/* Content Type Dropdown Styles */
+.content-type-dropdown {
+  margin-left: 8px;
+  padding: 4px 8px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  background-color: white;
+  color: #333;
+  border: 2px solid #3f51b5;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: Arial, Helvetica, sans-serif;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.content-type-dropdown:hover {
+  border-color: #303f9f;
+}
+
+.content-type-dropdown:focus {
+  border-color: #1a237e;
+  box-shadow: 0 0 0 2px rgba(63, 81, 181, 0.2);
+}
+
+.mdl-color--blue-grey-900 .content-type-dropdown {
+  background-color: #37474f;
+  color: #eceff1;
+  border-color: #7986cb;
+}
+
+.mdl-color--blue-grey-900 .content-type-dropdown:hover {
+  border-color: #5c6bc0;
+}
+
+.mdl-color--blue-grey-900 .content-type-dropdown:focus {
+  border-color: #3f51b5;
+  box-shadow: 0 0 0 2px rgba(121, 134, 203, 0.3);
+}
+
+.mdl-color--blue-grey-900 .content-type-dropdown option {
+  background-color: #37474f;
+  color: #eceff1;
+}
+
 #results {
   display: none;
   position: fixed;

--- a/public/js/results-display.js
+++ b/public/js/results-display.js
@@ -48,8 +48,21 @@ function highlightResults(data) {
       
       var widget = editor.getDoc().addLineWidget(lineNumber, msg);
       
+      // Add Fix button for custom AsciiDocDITA fixes
+      if (isCustomFixableIssue(data[i].Check)) {
+        var fixButton = document.createElement("button");
+        fixButton.textContent = " [Fix]";
+        fixButton.className = "inline-fix-button";
+        fixButton.setAttribute("data-issue-index", i);
+        fixButton.onclick = (function(issue, mkr, wgt) {
+          return function() {
+            applyCustomFix(issue, mkr, wgt, widgetsError, "error");
+          };
+        })(data[i], marker, widget);
+        msg.appendChild(fixButton);
+      }
       // Add Fix button if action exists (after widget is created)
-      if (data[i].Action && data[i].Action.Name) {
+      else if (data[i].Action && data[i].Action.Name) {
         var fixButton = document.createElement("button");
         fixButton.textContent = " [Fix]";
         fixButton.className = "inline-fix-button";
@@ -102,8 +115,21 @@ function highlightResults(data) {
       
       var widget = editor.getDoc().addLineWidget(lineNumber, msg);
       
+      // Add Fix button for custom AsciiDocDITA fixes
+      if (isCustomFixableIssue(data[i].Check)) {
+        var fixButton = document.createElement("button");
+        fixButton.textContent = " [Fix]";
+        fixButton.className = "inline-fix-button";
+        fixButton.setAttribute("data-issue-index", i);
+        fixButton.onclick = (function(issue, mkr, wgt) {
+          return function() {
+            applyCustomFix(issue, mkr, wgt, widgetsWarning, "warning");
+          };
+        })(data[i], marker, widget);
+        msg.appendChild(fixButton);
+      }
       // Add Fix button if action exists (after widget is created)
-      if (data[i].Action && data[i].Action.Name) {
+      else if (data[i].Action && data[i].Action.Name) {
         var fixButton = document.createElement("button");
         fixButton.textContent = " [Fix]";
         fixButton.className = "inline-fix-button";
@@ -156,8 +182,21 @@ function highlightResults(data) {
       
       var widget = editor.getDoc().addLineWidget(lineNumber, msg);
       
+      // Add Fix button for custom AsciiDocDITA fixes
+      if (isCustomFixableIssue(data[i].Check)) {
+        var fixButton = document.createElement("button");
+        fixButton.textContent = " [Fix]";
+        fixButton.className = "inline-fix-button";
+        fixButton.setAttribute("data-issue-index", i);
+        fixButton.onclick = (function(issue, mkr, wgt) {
+          return function() {
+            applyCustomFix(issue, mkr, wgt, widgetsSuggestion, "suggestion");
+          };
+        })(data[i], marker, widget);
+        msg.appendChild(fixButton);
+      }
       // Add Fix button if action exists (after widget is created)
-      if (data[i].Action && data[i].Action.Name) {
+      else if (data[i].Action && data[i].Action.Name) {
         var fixButton = document.createElement("button");
         fixButton.textContent = " [Fix]";
         fixButton.className = "inline-fix-button";
@@ -266,6 +305,217 @@ function updateCounts() {
   // Update Convert to DITA button visibility
   if (typeof updateConvertToDitaButtonVisibility !== "undefined") {
     updateConvertToDitaButtonVisibility();
+  }
+}
+
+// Check if issue is a custom fixable AsciiDocDITA issue
+function isCustomFixableIssue(checkName) {
+  return checkName === "AsciiDocDITA.ContentType" ||
+         checkName === "AsciiDocDITA.ShortDescription" ||
+         checkName === "AsciiDocDITA.BlockTitle";
+}
+
+// Route to appropriate custom fix based on issue type
+function applyCustomFix(issue, marker, widget, widgetArray, severity) {
+  var checkName = issue.Check;
+  
+  try {
+    if (checkName === "AsciiDocDITA.ContentType") {
+      applyContentTypeFix(issue, marker, widget, widgetArray);
+    } else if (checkName === "AsciiDocDITA.ShortDescription") {
+      applyShortDescriptionFix(issue, marker, widget, widgetArray);
+    } else if (checkName === "AsciiDocDITA.BlockTitle") {
+      applyBlockTitleFix(issue, marker, widget, widgetArray);
+    }
+  } catch (error) {
+    console.error("Error applying custom fix:", error);
+    showNotification("Error applying fix: " + error.message);
+  }
+}
+
+// Fix for AsciiDocDITA.ContentType - Show dropdown to select content type
+function applyContentTypeFix(issue, marker, widget, widgetArray) {
+  // Create dropdown element
+  var dropdown = document.createElement("select");
+  dropdown.className = "content-type-dropdown";
+  
+  var options = ["ASSEMBLY", "CONCEPT", "REFERENCE", "PROCEDURE", "SNIPPET"];
+  
+  // Add placeholder option
+  var placeholderOption = document.createElement("option");
+  placeholderOption.textContent = "Select content type...";
+  placeholderOption.value = "";
+  placeholderOption.disabled = true;
+  placeholderOption.selected = true;
+  dropdown.appendChild(placeholderOption);
+  
+  // Add content type options
+  options.forEach(function(optionValue) {
+    var option = document.createElement("option");
+    option.value = optionValue;
+    option.textContent = optionValue;
+    dropdown.appendChild(option);
+  });
+  
+  // Handle selection
+  dropdown.onchange = function() {
+    if (dropdown.value) {
+      insertContentType(dropdown.value, marker, widget, widgetArray);
+      dropdown.remove();
+    }
+  };
+  
+  // Add dropdown to the widget
+  widget.node.appendChild(dropdown);
+  dropdown.focus();
+}
+
+// Insert content type attribute after comments
+function insertContentType(contentType, marker, widget, widgetArray) {
+  var doc = editor.getDoc();
+  var totalLines = doc.lineCount();
+  var insertLine = 0;
+  
+  // Find the last comment line or the beginning
+  for (var i = 0; i < totalLines; i++) {
+    var lineText = doc.getLine(i).trim();
+    if (lineText.startsWith("//")) {
+      insertLine = i + 1;
+    } else if (lineText !== "") {
+      // Found first non-empty, non-comment line
+      break;
+    }
+  }
+  
+  // Build the text to insert with blank lines
+  var textToInsert = "\n:_mod-docs-content-type: " + contentType + "\n";
+  
+  // Insert at the appropriate position
+  doc.replaceRange(textToInsert, { line: insertLine, ch: 0 });
+  
+  // Clear the marker and remove widget
+  marker.clear();
+  var widgetIndex = widgetArray.indexOf(widget);
+  if (widgetIndex > -1) {
+    widgetArray.splice(widgetIndex, 1);
+  }
+  doc.removeLineWidget(widget);
+  
+  // Update counts
+  updateCounts();
+  showNotification("Content type added successfully!");
+}
+
+// Fix for AsciiDocDITA.ShortDescription - Add [role="_abstract"] after title
+function applyShortDescriptionFix(issue, marker, widget, widgetArray) {
+  var doc = editor.getDoc();
+  var totalLines = doc.lineCount();
+  var titleLine = -1;
+  
+  // Find the title line (starts with single =)
+  for (var i = 0; i < totalLines; i++) {
+    var lineText = doc.getLine(i);
+    if (lineText.match(/^=\s+\S/)) {
+      titleLine = i;
+      break;
+    }
+  }
+  
+  if (titleLine === -1) {
+    showNotification("Error: Could not find title line (starting with =)");
+    return;
+  }
+  
+  // Check if there's already a blank line after title
+  var nextLineAfterTitle = titleLine + 1;
+  var hasBlankLine = false;
+  
+  if (nextLineAfterTitle < totalLines) {
+    var nextLineText = doc.getLine(nextLineAfterTitle).trim();
+    if (nextLineText === "") {
+      hasBlankLine = true;
+    }
+  }
+  
+  // Insert [role="_abstract"] with proper spacing
+  var insertText;
+  if (hasBlankLine) {
+    // Blank line exists, insert role on the next line after it
+    insertText = "[role=\"_abstract\"]\n\n";
+    doc.replaceRange(insertText, { line: nextLineAfterTitle + 1, ch: 0 });
+  } else {
+    // No blank line, add blank line and then role
+    insertText = "\n\n[role=\"_abstract\"]\n";
+    doc.replaceRange(insertText, { line: titleLine + 1, ch: 0 });
+  }
+  
+  // Clear the marker and remove widget
+  marker.clear();
+  var widgetIndex = widgetArray.indexOf(widget);
+  if (widgetIndex > -1) {
+    widgetArray.splice(widgetIndex, 1);
+  }
+  doc.removeLineWidget(widget);
+  
+  // Update counts
+  updateCounts();
+  showNotification("Abstract role added successfully!");
+}
+
+// Fix for AsciiDocDITA.BlockTitle - Remove block title lines starting with .
+function applyBlockTitleFix(issue, marker, widget, widgetArray) {
+  var doc = editor.getDoc();
+  var lineNumber = issue.Line - 1;
+  var startChar = issue.Span[0] - 1;
+  var endChar = issue.Span[1];
+  var foundLine = -1;
+  
+  // Search for a line starting with . followed by a character in a range around the issue line
+  // (line numbers may have shifted due to previous fixes)
+  var searchRange = 5; // Search 5 lines before and after
+  var startSearch = Math.max(0, lineNumber - searchRange);
+  var endSearch = Math.min(doc.lineCount() - 1, lineNumber + searchRange);
+  
+  // Regex to match lines starting with . followed by a character (e.g., .Example, .Table)
+  var blockTitleRegex = /^\.\S/;
+  
+  for (var i = startSearch; i <= endSearch; i++) {
+    var lineText = doc.getLine(i);
+    
+    // Check if line matches block title pattern
+    if (blockTitleRegex.test(lineText)) {
+      // Verify the span matches - check if the columns are in valid range for this line
+      if (startChar >= 0 && endChar <= lineText.length) {
+        foundLine = i;
+        break;
+      } else if (endChar <= lineText.length) {
+        // If only endChar is valid, still consider it a match
+        foundLine = i;
+        break;
+      }
+    }
+  }
+  
+  if (foundLine !== -1) {
+    // Delete the entire line
+    doc.replaceRange("", 
+      { line: foundLine, ch: 0 },
+      { line: foundLine + 1, ch: 0 }
+    );
+    
+    // Clear the marker and remove widget
+    marker.clear();
+    var widgetIndex = widgetArray.indexOf(widget);
+    if (widgetIndex > -1) {
+      widgetArray.splice(widgetIndex, 1);
+    }
+    doc.removeLineWidget(widget);
+    
+    // Update counts
+    updateCounts();
+    showNotification("Block title removed successfully!");
+  } else {
+    showNotification("Error: Could not find block title line (starting with . followed by text)");
   }
 }
 


### PR DESCRIPTION
This pull request introduces new custom "Fix" actions for specific AsciiDocDITA issues in the editor, allowing users to automatically resolve common linting problems with a single click. It also adds styling for a new content type dropdown and increments the application version.

New automated fixes and UI improvements:

**Custom Fix Actions for AsciiDocDITA Issues**
- Added logic to detect three specific AsciiDocDITA issues (`ContentType`, `ShortDescription`, `BlockTitle`) and display a custom "Fix" button for each. When clicked, these buttons automatically apply the appropriate fix directly in the editor. 
- Implemented the following custom fixes:
  - For `AsciiDocDITA.ContentType`: Shows a dropdown to select a content type and inserts the corresponding attribute in the document.
  - For `AsciiDocDITA.ShortDescription`: Inserts `[role="_abstract"]` after the document title if missing.
  - For `AsciiDocDITA.BlockTitle`: Removes lines that start with a block title (a dot followed by text).

**Styling Enhancements**
- Added CSS styles for the new content type dropdown to ensure it integrates well with both light and dark themes.

**Version Update**
- Incremented the application version from `2.0.0` to `2.0.1` in `package.json`.